### PR TITLE
add direnv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/target
 /Cargo.lock
+.direnv


### PR DESCRIPTION
after cloning the repo and executing direnv allow the git repo is dirty, because direnv is not part of .gitignore