### PR TITLE
fix: compile error with optional nuts

### DIFF
--- a/bindings/cashu-sdk-ffi/Cargo.toml
+++ b/bindings/cashu-sdk-ffi/Cargo.toml
@@ -9,14 +9,12 @@ rust-version.workspace = true
 name = "cashu_sdk_ffi"
 crate-type = ["cdylib", "staticlib"]
 
-
 [dependencies]
 cashu-ffi = { path = "../cashu-ffi" }
-cashu-sdk = { path = "../../crates/cashu-sdk", default-features = false, features = ["wallet", "mint", "blocking"] }
+cashu-sdk = { path = "../../crates/cashu-sdk", default-features = false, features = ["wallet", "mint", "blocking", "nut07", "nut09"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uniffi = { workspace = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }
-

--- a/crates/cashu-sdk/src/client/blocking.rs
+++ b/crates/cashu-sdk/src/client/blocking.rs
@@ -68,7 +68,7 @@ impl Client {
     #[cfg(feature = "nut07")]
     pub fn check_spendable(
         &self,
-        proofs: &Vec<nut00::mint::Proof>,
+        proofs: &Vec<cashu::nuts::nut00::mint::Proof>,
     ) -> Result<CheckSpendableResponse, Error> {
         RUNTIME.block_on(async { self.client.check_spendable(proofs).await })
     }


### PR DESCRIPTION
running "just build" local results in multiple compile errors. This is a fix for the first one:

`error[E0599]: no method named `check_spendable` found for struct `cashu_sdk::client::blocking::Client` in the current scope
  --> bindings/cashu-sdk-ffi/src/client.rs:97:18
   |
96 | / ...   self.inner
97 | | ...       .check_spendable(&proofs.iter().map(|p| p.as_ref().deref().clone()).collect())?
   | |           -^^^^^^^^^^^^^^^ method not found in `Client`
   | |___________|
   | 

error[E0599]: no method named `get_info` found for struct `cashu_sdk::client::blocking::Client` in the current scope
   --> bindings/cashu-sdk-ffi/src/client.rs:103:32
    |
103 |         Ok(Arc::new(self.inner.get_info()?.into()))
    |                                ^^^^^^^^ method not found in `Client`
`  
I think CI didn't catch this one, because CI never builds the full workspace without any feature flags like "just build" does.
