### PR TITLE
consolidate split-amount

### DIFF
--- a/crates/cashu/src/amount.rs
+++ b/crates/cashu/src/amount.rs
@@ -84,3 +84,25 @@ impl core::iter::Sum for Amount {
         Amount::from(sats)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_amount() {
+        assert_eq!(Amount::from_sat(1).split(), vec![Amount::from_sat(1)]);
+        assert_eq!(Amount::from_sat(2).split(), vec![Amount::from_sat(2)]);
+        assert_eq!(
+            Amount::from_sat(3).split(),
+            vec![Amount::from_sat(2), Amount::from_sat(1)]
+        );
+        let amounts: Vec<Amount> = [8, 2, 1].iter().map(|a| Amount::from_sat(*a)).collect();
+        assert_eq!(Amount::from_sat(11).split(), amounts);
+        let amounts: Vec<Amount> = [128, 64, 32, 16, 8, 4, 2, 1]
+            .iter()
+            .map(|a| Amount::from_sat(*a))
+            .collect();
+        assert_eq!(Amount::from_sat(255).split(), amounts);
+    }
+}

--- a/crates/cashu/src/nuts/nut00.rs
+++ b/crates/cashu/src/nuts/nut00.rs
@@ -35,7 +35,6 @@ pub mod wallet {
     use crate::nuts::nut01;
     use crate::secret::Secret;
     use crate::url::UncheckedUrl;
-    use crate::utils::split_amount;
     use crate::{error, Amount};
 
     /// Blinded Messages [NUT-00]
@@ -56,7 +55,7 @@ pub mod wallet {
         pub fn random(amount: Amount) -> Result<Self, wallet::Error> {
             let mut blinded_messages = BlindedMessages::default();
 
-            for amount in split_amount(amount) {
+            for amount in amount.split() {
                 let secret = Secret::new();
                 let (blinded, r) = blind_message(secret.as_bytes(), None)?;
 

--- a/crates/cashu/src/utils.rs
+++ b/crates/cashu/src/utils.rs
@@ -5,21 +5,6 @@ use bitcoin::hashes::Hash;
 use rand::prelude::*;
 use regex::Regex;
 
-use crate::Amount;
-
-/// Split amount into cashu denominations (powers of 2)
-pub fn split_amount(amount: Amount) -> Vec<Amount> {
-    let mut chunks = Vec::new();
-    let value = amount.to_sat();
-    for i in 0..64 {
-        let mask = 1 << i;
-        if (value & mask) != 0 {
-            chunks.push(Amount::from_sat(2u64.pow(i as u32)));
-        }
-    }
-    chunks
-}
-
 pub fn extract_url_from_error(error: &str) -> Option<String> {
     let regex = Regex::new(r"https?://[^\s]+").unwrap();
     if let Some(capture) = regex.captures(error) {
@@ -34,26 +19,4 @@ pub fn random_hash() -> Vec<u8> {
     rng.fill_bytes(&mut random_bytes);
     let hash = Sha256::hash(&random_bytes);
     hash.to_byte_array().to_vec()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_split_amount() {
-        assert_eq!(split_amount(Amount::from_sat(1)), vec![Amount::from_sat(1)]);
-        assert_eq!(split_amount(Amount::from_sat(2)), vec![Amount::from_sat(2)]);
-        assert_eq!(
-            split_amount(Amount::from_sat(3)),
-            vec![Amount::from_sat(1), Amount::from_sat(2)]
-        );
-        let amounts: Vec<Amount> = [1, 2, 8].iter().map(|a| Amount::from_sat(*a)).collect();
-        assert_eq!(split_amount(Amount::from_sat(11)), amounts);
-        let amounts: Vec<Amount> = [1, 2, 4, 8, 16, 32, 64, 128]
-            .iter()
-            .map(|a| Amount::from_sat(*a))
-            .collect();
-        assert_eq!(split_amount(Amount::from_sat(255)), amounts);
-    }
 }


### PR DESCRIPTION
There are two implementations of a split amount function that can be consolidated. The function utils::split_amount() is only used once in nut00::random() and could be replaced by Amount.split(). The only difference of the two implementations is the order in which the amounts occur, but I think this doesn't matter for the one usage in the random() function.

The tests have been moved to the amount module and adopted to the new ordering of the implementation.