### PR TITLE
fix: typo insufficient funds

### DIFF
--- a/crates/cashu-sdk/src/wallet.rs
+++ b/crates/cashu-sdk/src/wallet.rs
@@ -23,8 +23,8 @@ use crate::client::Client;
 
 #[derive(Debug)]
 pub enum Error {
-    /// Insufficaint Funds
-    InsufficantFunds,
+    /// Insufficient Funds
+    InsufficientFunds,
     Cashu(cashu::error::wallet::Error),
     Client(crate::client::Error),
     Custom(String),
@@ -35,7 +35,7 @@ impl StdError for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::InsufficantFunds => write!(f, "Insufficant Funds"),
+            Error::InsufficientFunds => write!(f, "Insufficient Funds"),
             Error::Cashu(err) => write!(f, "{}", err),
             Error::Client(err) => write!(f, "{}", err),
             Error::Custom(err) => write!(f, "{}", err),
@@ -341,7 +341,7 @@ impl Wallet {
 
         if amount_available.lt(&amount) {
             println!("Not enough funds");
-            return Err(Error::InsufficantFunds);
+            return Err(Error::InsufficientFunds);
         }
 
         // If amount available is EQUAL to send amount no need to split
@@ -403,7 +403,7 @@ impl Wallet {
 
         if amount_available.lt(&amount) {
             println!("Not enough funds");
-            return Err(Error::InsufficantFunds);
+            return Err(Error::InsufficientFunds);
         }
 
         // If amount available is EQUAL to send amount no need to split

--- a/crates/cashu/src/error.rs
+++ b/crates/cashu/src/error.rs
@@ -92,8 +92,8 @@ pub mod wallet {
         SerdeJsonError(serde_json::Error),
         /// From elliptic curve
         EllipticError(k256::elliptic_curve::Error),
-        /// Insufficaint Funds
-        InsufficantFunds,
+        /// Insufficient Funds
+        InsufficientFunds,
         /// Utf8 parse error
         Utf8ParseError(FromUtf8Error),
         /// Base64 error
@@ -114,7 +114,7 @@ pub mod wallet {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             match self {
                 Error::CustomError(err) => write!(f, "{}", err),
-                Error::InsufficantFunds => write!(f, "Insufficant Funds"),
+                Error::InsufficientFunds => write!(f, "Insufficient Funds"),
                 Error::Utf8ParseError(err) => write!(f, "{}", err),
                 Error::Base64Error(err) => write!(f, "{}", err),
                 Error::UnsupportedToken => write!(f, "Unsuppported Token"),


### PR DESCRIPTION
typos-cli didn't catch this one