### PR TITLE
Decode and encode Token V4

### DIFF
--- a/crates/cashu/Cargo.toml
+++ b/crates/cashu/Cargo.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 homepage.workspace = true
 repository.workspace = true
 license.workspace = true
-rust-version.workspace = true # MSRV
+rust-version.workspace = true                      # MSRV
 description = "Cashu rust wallet and mint library"
 
 
@@ -27,12 +27,12 @@ nut13 = ["dep:bip39", "dep:bip32", "nut09"]
 
 [dependencies]
 base64 = "0.22.0"
-bitcoin = { version = "0.31.0", features=["serde",  "rand"] }
+bitcoin = { version = "0.31.0", features = ["serde", "rand"] }
 bip39 = { version = "2.0.0", optional = true }
 bip32 = { version = "0.5.1", optional = true }
 hex = "0.4.3"
-k256 = { version = "0.13.1", features=["arithmetic", "serde", "schnorr"] }
-lightning-invoice = { version = "0.29.0", features=["serde"] }
+k256 = { version = "0.13.1", features = ["arithmetic", "serde", "schnorr"] }
+lightning-invoice = { version = "0.29.0", features = ["serde"] }
 log = "0.4.2"
 rand = "0.8.5"
 serde = { workspace = true }
@@ -42,7 +42,7 @@ url = { workspace = true }
 itertools = "0.12.0"
 thiserror = { workspace = true }
 uuid = { version = "1.6.1", features = ["v4"] }
-ciborium = "0.2.2"
+ciborium = { version = "0.2.2", default-features = false, features = ["std"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { workspace = true }

--- a/crates/cashu/Cargo.toml
+++ b/crates/cashu/Cargo.toml
@@ -42,6 +42,7 @@ url = { workspace = true }
 itertools = "0.12.0"
 thiserror = { workspace = true }
 uuid = { version = "1.6.1", features = ["v4"] }
+ciborium = "0.2.2"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { workspace = true }

--- a/crates/cashu/src/error.rs
+++ b/crates/cashu/src/error.rs
@@ -98,6 +98,9 @@ pub mod wallet {
         /// Serde Json error
         #[error("`{0}`")]
         SerdeJsonError(#[from] serde_json::Error),
+        /// Ciborium error
+        #[error("`{0}`")]
+        CiboriumError(#[from] ciborium::de::Error<std::io::Error>),
         /// From elliptic curve
         #[error("`{0}`")]
         EllipticError(#[from] k256::elliptic_curve::Error),

--- a/crates/cashu/src/nuts/nut00.rs
+++ b/crates/cashu/src/nuts/nut00.rs
@@ -409,6 +409,16 @@ pub mod wallet {
         }
     }
 
+    impl From<TokenV4> for Token {
+        fn from(token: TokenV4) -> Self {
+            Token {
+                token: token.token.into_iter().map(Into::into).collect(),
+                memo: token.memo,
+                unit: token.unit,
+            }
+        }
+    }
+
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     struct TokenV4 {
         #[serde(rename = "t")]
@@ -439,16 +449,6 @@ pub mod wallet {
             }
         }
     }
-
-    impl Into<Token> for TokenV4 {
-        fn into(self) -> Token {
-            Token {
-                token: self.token.into_iter().map(Into::into).collect(),
-                memo: self.memo,
-                unit: self.unit,
-            }
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -467,6 +467,15 @@ impl MintProofs {
     }
 }
 
+impl From<MintProofsV4> for MintProofs {
+    fn from(mint_proofs: MintProofsV4) -> Self {
+        MintProofs {
+            mint: mint_proofs.mint,
+            proofs: mint_proofs.proofs.into_iter().map(From::from).collect(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct MintProofsV4 {
     #[serde(rename = "m")]
@@ -480,15 +489,6 @@ impl From<MintProofs> for MintProofsV4 {
         MintProofsV4 {
             mint: mint_proofs.mint,
             proofs: mint_proofs.proofs.into_iter().map(From::from).collect(),
-        }
-    }
-}
-
-impl Into<MintProofs> for MintProofsV4 {
-    fn into(self) -> MintProofs {
-        MintProofs {
-            mint: self.mint,
-            proofs: self.proofs.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -567,6 +567,21 @@ impl PartialOrd for Proof {
     }
 }
 
+impl From<ProofV4> for Proof {
+    fn from(proof: ProofV4) -> Self {
+        Proof {
+            amount: proof.amount,
+            keyset_id: proof.keyset_id,
+            secret: proof.secret,
+            c: proof.c,
+            #[cfg(feature = "nut11")]
+            witness: proof.witness,
+            #[cfg(feature = "nut12")]
+            dleq: proof.dleq,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProofV4 {
     /// Amount in satoshi
@@ -614,7 +629,7 @@ where
     D: serde::Deserializer<'de>,
 {
     let bytes = Vec::<u8>::deserialize(deserializer)?;
-    Ok(Id::from_bytes(&bytes).map_err(serde::de::Error::custom)?)
+    Id::from_bytes(&bytes).map_err(serde::de::Error::custom)
 }
 
 // fn serialize_v4_secret<S>(secret: &Secret, serializer: S) -> Result<S::Ok, S::Error>
@@ -646,7 +661,7 @@ where
     D: serde::Deserializer<'de>,
 {
     let bytes = Vec::<u8>::deserialize(deserializer)?;
-    Ok(PublicKey::from_bytes(&bytes).map_err(serde::de::Error::custom)?)
+    PublicKey::from_bytes(&bytes).map_err(serde::de::Error::custom)
 }
 
 impl From<Proof> for ProofV4 {
@@ -660,21 +675,6 @@ impl From<Proof> for ProofV4 {
             witness: proof.witness,
             #[cfg(feature = "nut12")]
             dleq: proof.dleq,
-        }
-    }
-}
-
-impl Into<Proof> for ProofV4 {
-    fn into(self) -> Proof {
-        Proof {
-            amount: self.amount,
-            keyset_id: self.keyset_id,
-            secret: self.secret,
-            c: self.c,
-            #[cfg(feature = "nut11")]
-            witness: self.witness,
-            #[cfg(feature = "nut12")]
-            dleq: self.dleq,
         }
     }
 }

--- a/crates/cashu/src/nuts/nut01.rs
+++ b/crates/cashu/src/nuts/nut01.rs
@@ -77,6 +77,10 @@ impl PublicKey {
     pub fn to_bytes(&self) -> Box<[u8]> {
         self.0.to_sec1_bytes()
     }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        Ok(PublicKey(k256::PublicKey::from_sec1_bytes(bytes)?))
+    }
 }
 
 impl From<PublicKey> for Box<[u8]> {

--- a/crates/cashu/src/nuts/nut02.rs
+++ b/crates/cashu/src/nuts/nut02.rs
@@ -45,6 +45,15 @@ pub struct Id {
 
 impl Id {
     const STRLEN: usize = 14;
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        hex::decode(self.to_string()).unwrap()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+        let hex = hex::encode(bytes);
+        Self::from_str(&hex)
+    }
 }
 
 impl TryFrom<Id> for u64 {

--- a/crates/cashu/src/nuts/nut12.rs
+++ b/crates/cashu/src/nuts/nut12.rs
@@ -118,7 +118,7 @@ impl Proof {
         let c: k256::PublicKey = (&self.c).into();
         let mint_pubkey: k256::PublicKey = mint_pubkey.into();
 
-        let y = hash_to_curve(self.secret.0.as_bytes())?;
+        let y = hash_to_curve(&self.secret.to_bytes())?;
         let blinded_signature = c.to_projective()
             + mint_pubkey
                 .as_affine()


### PR DESCRIPTION
Closes #68 

I have an open question on the draft NUT if secrets should be bytes instead of strings: https://github.com/cashubtc/nuts/pull/109/files#r1555859864. However, as it stands, this successfully decodes and encodes v4 tokens.